### PR TITLE
Correct word usage.

### DIFF
--- a/docs/compute/pricing.rst
+++ b/docs/compute/pricing.rst
@@ -29,10 +29,10 @@ Where does the Libcloud pricing data come from?
 -----------------------------------------------
 
 Most of the providers don't provide pricing information via the API which means
-most of the pricing information is scrapped directly from the provider
+most of the pricing information is scraped directly from the provider
 websites.
 
-Pricing data which is scrapped from the provider websites is located in a
+Pricing data which is scraped from the provider websites is located in a
 JSON file (``data/pricing.json``) which is bundled with each release. This
 pricing data is only updated once you install a new release which means it
 could be out of date.


### PR DESCRIPTION
## Correct word usage.

### Description

Noticed an incorrect word usage.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)

Past tense of scrape is scraped; not scrapped.